### PR TITLE
Fix Space Update 

### DIFF
--- a/client/space.go
+++ b/client/space.go
@@ -592,7 +592,7 @@ func (c *Client) UpdateGroup(groupName string, description string, idpId string,
 // 	"icon": "screen"
 // },
 
-func (c *Client) UpdateSpace(name string, color string, icon string) error {
+func (c *Client) UpdateSpace(current_space string, name string, color string, icon string) error {
 
 	data := Space{
 		Name:  name,
@@ -605,7 +605,7 @@ func (c *Client) UpdateSpace(name string, color string, icon string) error {
 		log.Fatalf("impossible to marshall update space request: %s", err)
 	}
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%sapi/spaces/%s", c.HostURL, name), bytes.NewReader(payload))
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%sapi/spaces/%s", c.HostURL, current_space), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resources/space_resource.go
+++ b/internal/provider/resources/space_resource.go
@@ -142,11 +142,11 @@ func (r *TorqueSpaceResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *TorqueSpaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan,state TorqueSpaceResourceModel
+	var plan, state TorqueSpaceResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	diags := req.Plan.Get(ctx, &plan)
-	
+
 	current_space := state.Name
 
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/space_resource.go
+++ b/internal/provider/space_resource.go
@@ -142,37 +142,41 @@ func (r *TorqueSpaceResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *TorqueSpaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data TorqueSpaceResourceModel
+	var plan,state TorqueSpaceResourceModel
 
-	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	diags := req.Plan.Get(ctx, &plan)
+	
+	current_space := state.Name
+
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Update existing order
-	err := r.client.UpdateSpace(data.Name.ValueString(), data.Color.ValueString(), data.Icon.ValueString())
+	err := r.client.UpdateSpace(current_space.ValueString(), plan.Name.ValueString(), plan.Color.ValueString(), plan.Icon.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Torque space",
-			"Could not update group, unexpected error: "+err.Error(),
+			"Could not update Torque Space name, unexpected error: "+err.Error(),
 		)
 		return
 	}
 
-	space, err := r.client.GetSpace(data.Name.ValueString())
+	space, err := r.client.GetSpace(plan.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading space details",
-			"Could not read Torque group name "+data.Name.ValueString()+": "+err.Error(),
+			"Could not read Torque Space name "+plan.Name.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
-	data.Color = types.StringValue(space.Color)
-	data.Icon = types.StringValue(space.Icon)
+	plan.Color = types.StringValue(space.Color)
+	plan.Icon = types.StringValue(space.Icon)
 
-	diags = resp.State.Set(ctx, data)
+	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
Fixed an issue with updating torque_space resource space_name attribute that was caused due to using the same updated space_name both as the parameter to the PUT api call and as the desired new name.
Fixed by extracting the space_name from state and add it as argument to the function responsible for making the PUT call. 